### PR TITLE
Adding an entry point for another npm package to use both scroll classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scroll"
   ],
   "license": "MIT",
-  "main": "src/scroll.js",
+  "main": "src/index.js",
   "devDependencies": {
     "build-tools": "^1.5.2",
     "grunt": "^0.4.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+    Scroll: require('./scroll'),
+    ScrollListener: require('./scroll-listener')
+};


### PR DESCRIPTION
Previously, only `Scroll` was available when importing this package.  This PR allows for `ScrollListener` to be available, as well.