### PR TITLE
Fix bower dependency of promise lib

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     "tests"
   ],
   "dependencies": {
-    "promise": "^7.1.1"
+    "promise": "then/promise#^7.1.1"
   }
 }


### PR DESCRIPTION
It's not actually published as `promise` in bower so it's important to provide github org name.