### PR TITLE
package: Lower engine version requirement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=7.4.0"
+    "node": ">=4.0.0"
   },
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
This lowers the engine version to the earliest LTS version of NodeJS
(v4). v7 is a pretty strict version requirement, and it's also not going
to be an LTS version.

While the engine version only throws a warning in `npm`, it throws an
error in `yarn` and breaks builds.