### PR TITLE
Add some initialization help

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ scroll.to(0, 300); // scroll to trigger event
 
 ```
 
+## API
+
+### Methods
+
+[Scroll.constructor(\[containerElement:HTMLElement\])](#scroll-constructor)
+
+Constructor initializes an element to be scrollable. Defaults to `document.body`.
+
+[Scroll.to(x:Number, y:Number, \[options:Object\])](#scroll-to)
+
+Scrolls the `containerElement` by the supplied `x` and `y` coordinates.
+
+
+[Scroll.toElement(element:HTMLElement, \[options:Object\])](#scroll-to-element)
+
+Scrolls the `containerElement` until it reaches the specified `element`. 
+
+
+### Options
+
+| Option | Type | Description |
+|--------|--------|--------|
+| `duration`| Number| The number of milliseconds the scroll will take to complete
+| `easing`| String | The easing to use when scrolling
+
+
 
 ## Development
 

--- a/src/scroll.js
+++ b/src/scroll.js
@@ -48,10 +48,10 @@ export default class Scroll {
      * @param {HTMLElement} el - The element to scroll (the viewport)
      */
     constructor (el) {
-        if (!el) {
-            console.error('Scroll error: element passed to Scroll constructor is ' + el + '! Bailing...');
+        if (el && !(el instanceof Node)) {
+            throw new Error(`Scroll error: element passed to Scroll constructor must be a DOM node, you passed ${el}!`);
         }
-        this.el = el;
+        this.el = el || document.body;
     }
 
     /**

--- a/tests/scroll-tests.js
+++ b/tests/scroll-tests.js
@@ -52,6 +52,27 @@ describe('Scroll', function () {
         window.requestAnimationFrame.restore();
     });
 
+    it('should throw an error when initializing with a value that is not a DOM node', function() {
+        let testValue = true;
+        assert.throws(() => {
+            new Scroll(testValue);
+        }, (e) => {
+            assert.equal(e.message, `Scroll error: element passed to Scroll constructor must be a DOM node, you passed ${testValue}!`);
+            return true;
+        });
+    });
+
+    it('should NOT throw an error when initializing with a value that is a DOM node', function() {
+        assert.doesNotThrow(() => {
+            new Scroll(document.createElement('div'));
+        });
+    });
+
+    it('should set the container el as document.body if nothing is passed to constructor', function() {
+        let scroll = new Scroll();
+        assert.deepEqual(scroll.el, document.body)
+    });
+
     it('should update its element\'s scrollTop property to the same coordinate specified in the second parameter supplied to scroll.to()', function() {
 
         let dateNowStub = sinon.stub(Date, 'now');


### PR DESCRIPTION
Adds a few helpful features to minimize labor for consumer's of this package.

* Default container element to `document.body` when no container is passed to Scroll constructor
* Fail when attempting to pass a container to the constructor that is not a DOM node (per https://github.com/mkay581/scroll-js/issues/15#issuecomment-309741752)
* Adds methods to README