### PR TITLE
Fix scrolling back to top

### DIFF
--- a/src/scroll.ts
+++ b/src/scroll.ts
@@ -58,7 +58,7 @@ export async function scrollTo(
     return new Promise(resolve => {
         scroll(
             currentScrollPosition,
-            options.top || currentScrollPosition,
+            typeof options.top === 'number' ? options.top : currentScrollPosition,
             scrollProperty,
             Date.now(),
             options.duration,
@@ -158,6 +158,7 @@ function getScrollPosition(el: Element | Window): number {
 }
 
 function setScrollPosition(el: Element | Window, value: number) {
+    const document = utils.getDocument();
     if (el === document.body || el === document.documentElement || el instanceof Window) {
         document.body.scrollTop = value;
         document.documentElement.scrollTop = value;

--- a/tests/scroll-to-tests.js
+++ b/tests/scroll-to-tests.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import { scrollTo, utils, easingMap } from '../src/scroll';
 import createMockRaf from 'mock-raf';
 
-const { assert } = chai;
+const { assert, expect } = chai;
 
 let mockRaf;
 
@@ -162,5 +162,32 @@ describe('scroll', function() {
                 `Scroll error: scroller does not support an easing option of "${easing}". Supported options are ${options}`
             );
         });
+    });
+
+    it('body should scroll back to top after having been scrolled', function(done) {
+        let fakeBodyElement = document.createElement('div');
+        fakeBodyElement.style.overflow = 'hidden';
+        fakeBodyElement.style.height = '150px';
+        let innerEl = document.createElement('div');
+        innerEl.style.height = '600px';
+        fakeBodyElement.appendChild(innerEl);
+        document.body.appendChild(fakeBodyElement);
+        const testTo = 120;
+        sinon.stub(utils, 'getDocument').returns({
+            body: fakeBodyElement,
+            documentElement: document.createElement('div')
+        });
+        scrollTo(fakeBodyElement, { top: testTo });
+        mockRaf.step({ count: 3 });
+        setTimeout(function() {
+            scrollTo(fakeBodyElement, { top: 0 });
+            mockRaf.step({ count: 3 });
+            setTimeout(function() {
+                expect(fakeBodyElement.scrollTop).to.equal(0);
+                utils.getDocument.restore();
+                document.body.removeChild(fakeBodyElement);
+                done();
+            }, 0);
+        }, 0);
     });
 });


### PR DESCRIPTION
Fixes an issue where scrolling back to a top value of 0 wasnt working after having scrolled down using a previous `top` value.