### PR TITLE
Remove instant behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ scrollTo(document.body, { top: 500 }).then(function() {
 ```javascript
 import { scrollIntoView } from 'scroll-js';
 var myElement = document.body.getElementsByClassName('my-element')[0];
-scrollIntoView(myElement, document.body, { behavior: 'instant' }).then(
+scrollIntoView(myElement, document.body, { behavior: 'smooth' }).then(
     function() {
         // done scrolling document's body to show myElement
     }
@@ -147,7 +147,7 @@ but some additional ones are provided by this library until supported natively.
 
 | Option     | Type   | Description  |
 | ---------- | ------ | -----------  |
-| `behavior` | String | The type of [scroll behavior](https://drafts.csswg.org/cssom-view/#enumdef-scrollbehavior) which can be set to `auto`, `instant`, or `smooth`. This is the recommended option since this is already natively supported. **If this is set, all other options are ignored**.                               |
+| `behavior` | String | The type of [scroll behavior](https://drafts.csswg.org/cssom-view/#enumdef-scrollbehavior) which can be set to `auto` or `smooth`. This is the recommended option since this is already natively supported. **If this is set, all other options are ignored**.                               |
 | `duration` | Number | The number of milliseconds the scroll will take to complete                                                                                                                                                                                                                                              |
 | `easing`   | String | The easing to use when scrolling. Only keyword values of the [animation-timing-function](https://drafts.csswg.org/css-animations/#animation-timing-function) are supported. But passing function values will eventually be supported also (ie. `cubic-bezier(0.1, 0.7, 1.0, 0.1)`, `steps(4, end)`, etc) |
 
@@ -165,7 +165,7 @@ A set of [ScrollIntoViewOptions](https://drafts.csswg.org/cssom-view/#dictdef-sc
 
 | Option     | Type   | Description |
 | ---------- | ------ | ---------------------------------------------------------------------------------------------------- |
-| `behavior` | String | The type of [scroll behavior](https://drafts.csswg.org/cssom-view/#enumdef-scrollbehavior) which can be set to `auto`, `instant`, or `smooth`. Defaults to `auto`. |
+| `behavior` | String | The type of [scroll behavior](https://drafts.csswg.org/cssom-view/#enumdef-scrollbehavior) which can be set to `auto` or `smooth`. Defaults to `auto`. |
 
 ## Examples
 

--- a/tests/scroll-to-tests.js
+++ b/tests/scroll-to-tests.js
@@ -130,7 +130,7 @@ describe('scroll', function() {
         }, 0);
     });
 
-    it("should update its element's scrollTop to value supplied to scrollTo() immediately when behavior is set to instant", function(done) {
+    it("should update its element's scrollTop to value supplied to scrollTo() immediately when duration is used", function(done) {
         let outerEl = document.createElement('div');
         let innerEl = document.createElement('div');
         outerEl.appendChild(innerEl);
@@ -143,7 +143,7 @@ describe('scroll', function() {
         // setup current scroll position
         outerEl.scrollTop = 100;
         let testTo = 120;
-        scrollTo(outerEl, { top: testTo, behavior: 'instant' });
+        scrollTo(outerEl, { top: testTo, duration: 1000 });
         mockRaf.step({ count: 2 });
         setTimeout(function() {
             assert.equal(outerEl.scrollTop, testTo);

--- a/tests/scroll-to-tests.js
+++ b/tests/scroll-to-tests.js
@@ -130,7 +130,7 @@ describe('scroll', function() {
         }, 0);
     });
 
-    it("should update its element's scrollTop to value supplied to scrollTo() immediately when duration is used", function(done) {
+    it("should update its element's scrollTop to value supplied to scrollTo() immediately when behavior is set to auto", function(done) {
         let outerEl = document.createElement('div');
         let innerEl = document.createElement('div');
         outerEl.appendChild(innerEl);
@@ -143,7 +143,7 @@ describe('scroll', function() {
         // setup current scroll position
         outerEl.scrollTop = 100;
         let testTo = 120;
-        scrollTo(outerEl, { top: testTo, duration: 1000 });
+        scrollTo(outerEl, { top: testTo, behavior: 'auto' });
         mockRaf.step({ count: 2 });
         setTimeout(function() {
             assert.equal(outerEl.scrollTop, testTo);


### PR DESCRIPTION
This removes support for the `instant` scroll behavior, which has been removed from the spec. Fixes #37